### PR TITLE
Fix #3: set focus to editor on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,18 @@
     window.addEventListener('DOMContentLoaded', (event) => {
         console.log('DOM fully loaded and parsed');
         fs.readFile('/note', 'utf8', function (err, data) {
+            const elem = document.querySelector('#editor');
             if (err) {
-                document.querySelector('#editor').innerHTML = "Welocome To My Notepad"
+                elem.innerHTML = "Welocome To My Notepad"
             }
-            else
+            else {
                 if (data) {
-                    document.querySelector('#editor').innerHTML = data;
+                    elem.innerHTML = data;
                 }
+            }
+
+            // Set focus to the editor
+            elem.focus();
         })
 
         var autosave = setInterval(setInterval(function () {


### PR DESCRIPTION
This change updates the startup logic so that it sets focus on the editor by default.  I also made a variable to cache access to the editor DOM node.